### PR TITLE
CANDI-913: Relax rest-client requirement

### DIFF
--- a/socketio-client.gemspec
+++ b/socketio-client.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   # specify any dependencies here; for example:
   # s.add_development_dependency "rspec"
-  s.add_dependency 'rest-client', '~> 1.8.0'
+  s.add_dependency 'rest-client', '>= 1.8.0'
 end

--- a/socketio-client.gemspec
+++ b/socketio-client.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "socketio-client"
-  s.version     = "0.0.4"
+  s.version     = "0.1.0"
   s.authors     = ["Lyon"]
   s.email       = ["lyon@delorum.com"]
   s.homepage    = "http://github.com/lyondhill/socket.io-ruby-client"


### PR DESCRIPTION
## What does this PR do?

Relaxes the rest-client requirement to allow 1.x and 2.x.

## Why is it needed?

rest-client 1.x isn't well supported on Ubuntu 18.04. This Confluence page explains more:

https://jobseeker.atlassian.net/wiki/spaces/DEV/pages/469467166/Complications+encountered#rest-client-compatibility

## References

https://jobseeker.atlassian.net/browse/CANDI-913